### PR TITLE
Update lib/route66.js

### DIFF
--- a/lib/route66.js
+++ b/lib/route66.js
@@ -5,13 +5,17 @@ async = require('async');
 
 url = require('url');
 
-Route66 = function(req, res) {
-  var i, method, requestUrl, route, values, _i, _len, _ref;
-  method = req.method === 'DELETE' ? 'del' : req.method.toLowerCase();
-  requestUrl = req.url.replace(url.parse(req.url).search, '');
+Route66 = function(req, res, next) {
+  var functions, i, method, requestUrl, route, values, _i, _len, _ref;
+  if (req.method === 'DELETE') {
+    method = 'del';
+  } else {
+    method = req.method.toLowerCase();
+  }
   _ref = Route66.routes[method];
   for (_i = 0, _len = _ref.length; _i < _len; _i++) {
     route = _ref[_i];
+    requestUrl = req.url.replace(url.parse(req.url).search, '');
     if (route.regex.test(requestUrl)) {
       values = route.regex.exec(requestUrl).slice(1);
       i = 0;
@@ -23,15 +27,17 @@ Route66 = function(req, res) {
         req.params[route.params[i]] = values[i];
         i++;
       }
-      return async.forEachSeries(route.functions, function(fn, nextFn) {
+      functions = route.functions;
+      return async.forEachSeries(functions, function(fn, nextFn) {
         fn(req, res, nextFn);
-        if (route.functions.length === 0) {
+        if (functions.length === 0) {
           return nextFn();
         }
-      }, function() {});
+      }, function(err) {
+          if (err) next(err);
+      });
     }
   }
-  res.statusCode = 404;
   if (Route66.notFoundRoute) {
     return Route66.notFoundRoute(req, res);
   } else {


### PR DESCRIPTION
Errors being thrown by route method handlers are being swallowed.  This change bubbles any error down the Connect pipeline so it can be handled using the standard errorHandler techniques (http://www.senchalabs.org/connect/errorHandler.html)
